### PR TITLE
feat: allow CARGO_REGISTRY_TOKEN verification to be skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Login with a cargo.io registry token and publish your crate.
 
 ### Environment
 
-- `CARGO_REGISTRY_TOKEN`: required token that is used to login against crates.io
+- `CARGO_REGISTRY_TOKEN`: required token that is used to login against crates.io.<br>
+This is not required or verified if both the `publish` and `alwaysVerifyToken` options are false.
 
 ### Options
 
@@ -16,6 +17,7 @@ Login with a cargo.io registry token and publish your crate.
 - `checkArgs`: Array of strings that contains additional arguments for `cargo check`
 - `publish`: Boolean that defines if `cargo publish` is executed (defaults to `true`)
 - `publishArgs`: Array of strings that contains additional arguments for `cargo publish`
+- `alwaysVerifyToken`: Boolean that causes `CARGO_REGISTRY_TOKEN` verification to be skipped if both it and `publish` are `false` (defaults to `true`)
 
 #### Full Configuration Example
 

--- a/src/PluginConfig.fs
+++ b/src/PluginConfig.fs
@@ -7,4 +7,5 @@ type PluginConfig =
         abstract checkArgs: string array option with get
         abstract publish: bool option with get
         abstract publishArgs: string array option with get
+        abstract alwaysVerifyToken: bool option with get
     end

--- a/test/VerifyConditionsTests.cs
+++ b/test/VerifyConditionsTests.cs
@@ -84,6 +84,12 @@ public class VerifyConditionsTests
         api
             .Setup(a => a.exec(It.IsAny<string[]>()))
             .Returns(new Tuple<string, string, int>("cargo 1.0.0", "", 0).AsAsync);
+        api
+            .Setup(a => a.isReadable(It.IsAny<string>()))
+            .Returns(Helpers.UnitAsync);
+        api
+            .Setup(a => a.isWritable(It.IsAny<string>()))
+            .Returns(Helpers.UnitAsync);
 
         await VerifyConditions.verifyConditions(api.Object, config.Object, ctx.Object).Run();
     }

--- a/test/VerifyConditionsTests.cs
+++ b/test/VerifyConditionsTests.cs
@@ -55,6 +55,40 @@ public class VerifyConditionsTests
     }
 
     [Fact]
+    public async Task ThrowsWhenNoRegistryTokenIsPresentAndNotPublishing()
+    {
+        var (ctx, log) = Context();
+        var api = new Mock<ExternalApi.IExternalApi>();
+        var config = new Mock<Config.PluginConfig>();
+        config.Setup(c => c.publish).Returns(false);
+
+        api
+            .Setup(a => a.exec(It.IsAny<string[]>()))
+            .Returns(new Tuple<string, string, int>("cargo 1.0.0", "", 0).AsAsync);
+
+        var ex = await Assert.ThrowsAsync<Errors.SemanticReleaseError>(
+            () => VerifyConditions.verifyConditions(api.Object, Config(), ctx.Object).Run());
+
+        Assert.Equal("CARGO_REGISTRY_TOKEN is not set.", ex.Message);
+    }
+
+    [Fact]
+    public async Task AllowsNoRegistryTokenIfNotPublishingAndCheckDisabled()
+    {
+        var (ctx, log) = Context();
+        var api = new Mock<ExternalApi.IExternalApi>();
+        var config = new Mock<Config.PluginConfig>();
+        config.Setup(c => c.publish).Returns(false);
+        config.Setup(c => c.alwaysVerifyToken).Returns(false);
+
+        api
+            .Setup(a => a.exec(It.IsAny<string[]>()))
+            .Returns(new Tuple<string, string, int>("cargo 1.0.0", "", 0).AsAsync);
+
+        await VerifyConditions.verifyConditions(api.Object, config.Object, ctx.Object).Run();
+    }
+
+    [Fact]
     public async Task ExecutesLoginIntoRegistry()
     {
         var (ctx, log) = Context(new()


### PR DESCRIPTION
To skip, both publish and new option 'alwaysVerifyToken' must be false

 This is useful for my workflow where I want to use this plugin to manage the version field in cargo.toml, but not publish to crates.io